### PR TITLE
feat: standalone bETH feeder func, proper timeout handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,8 @@
     "BETH_RATE_LIMITS": "readonly",
     "BETH_PRICE_LIMITS": "readonly",
     "STETH_RATE_LIMITS": "readonly",
-    "ETH_PRICE_LIMITS": "readonly"
+    "ETH_PRICE_LIMITS": "readonly",
+    "REQUEST_TIMEOUT": "readonly",
+    "process": "readonly"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.4.0",
+        "axios": "^0.21.4",
         "bignumber.js": "^9.0.1",
         "jsonrpc-lite": "^2.2.0"
       },
@@ -3546,9 +3547,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
+      "version": "16.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
+      "integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -4011,6 +4012,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -6920,7 +6929,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
       "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -25724,9 +25732,7 @@
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
       "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
       "dev": true,
-      "requires": {
-        "ethers": "^5.0.2"
-      }
+      "requires": {}
     },
     "@types/abstract-leveldown": {
       "version": "5.0.1",
@@ -25776,9 +25782,9 @@
       }
     },
     "@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
+      "version": "16.7.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.13.tgz",
+      "integrity": "sha512-pLUPDn+YG3FYEt/pHI74HmnJOWzeR+tOIQzUx93pi9M7D8OE7PSLr97HboXwk5F+JS+TLtWuzCOW97AHjmOXXA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -26146,6 +26152,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -28669,8 +28683,7 @@
     "follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "dev": true
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.4.0",
-        "axios": "^0.21.4",
         "bignumber.js": "^9.0.1",
         "jsonrpc-lite": "^2.2.0"
       },
@@ -4013,14 +4012,6 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -6929,6 +6920,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
       "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -26153,14 +26145,6 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -28683,7 +28667,8 @@
     "follow-redirects": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.4.0",
-    "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",
     "jsonrpc-lite": "^2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "format": "prettier --write '**/*.{js,css,json,md}'",
     "build": "esbuild ./src/index.js --bundle --outfile=./dist/worker.js --platform=node",
+    "build-standalone": "esbuild ./src/standalone.js --bundle --outfile=./dist/standalone.js --platform=node",
     "test": "export NODE_ENV=test && nyc mocha"
   },
   "author": "Bogdan Kovtun <psirex48@gmail.com>",
@@ -32,6 +33,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.4.0",
+    "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",
     "jsonrpc-lite": "^2.2.0"
   }

--- a/src/ethNodeRpc.js
+++ b/src/ethNodeRpc.js
@@ -59,7 +59,7 @@ const apiEndpoints = {
     for (let i = 0; i < endpoints.length; ++i) {
       const [response, error] = await runWithTimeout(
         globals.requestTimeout,
-        fetch(endpoints[i], payload),
+        () => fetch(endpoints[i], payload),
       )
       if (response && response.status === 200) {
         return response
@@ -72,9 +72,9 @@ const apiEndpoints = {
   },
 }
 
-function runWithTimeout(timeout, callback) {
+function runWithTimeout(timeout, task) {
   return Promise.race([
-    callback,
+    task(),
     new Promise((_, reject) =>
       setTimeout(() => reject(new Error('Timeout Exceeded')), timeout),
     ),

--- a/src/globals.js
+++ b/src/globals.js
@@ -7,6 +7,7 @@ export const globals = {
   ethRpcs: [],
   deviationBlockOffsets: [],
   bEthSafePriceValidator: new BEthSafePriceValidator(),
+  requestTimeout: 30000,
 }
 
 export function setGlobals({
@@ -19,6 +20,7 @@ export function setGlobals({
   bEthPriceLimits,
   stEthRateLimits,
   ethPriceLimits,
+  requestTimeout,
 }) {
   globals.env = env || globals.env
   globals.sentryProjectId = sentryProjectId || globals.sentryProjectId
@@ -33,4 +35,5 @@ export function setGlobals({
     stEthRate: stEthRateLimits,
     ethPrice: ethPriceLimits,
   })
+  globals.requestTimeout = requestTimeout || globals.requestTimeout
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ setGlobals({
   bEthPriceLimits: BETH_PRICE_LIMITS && JSON.parse(BETH_PRICE_LIMITS),
   stEthRateLimits: STETH_RATE_LIMITS && JSON.parse(STETH_RATE_LIMITS),
   ethPriceLimits: ETH_PRICE_LIMITS && JSON.parse(ETH_PRICE_LIMITS),
+  requestTimeout: REQUEST_TIMEOUT && Number.parseInt(REQUEST_TIMEOUT, 10),
 })
 
 addEventListener('fetch', event => {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -27,7 +27,7 @@ setGlobals({
   env: ENV,
   sentryProjectId: SENTRY_PROJECT_ID,
   sentryKey: SENTRY_KEY,
-  ethRpcs: JSON.parse(ETH_RPCS),
+  ethRpcs: JSON.parse(ETH_RPCS || '[]'),
   deviationBlockOffsets:
     DEVIATION_BLOCK_OFFSETS && JSON.parse(DEVIATION_BLOCK_OFFSETS),
   bEthRateLimits: BETH_RATE_LIMITS && JSON.parse(BETH_RATE_LIMITS),

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -33,6 +33,7 @@ setGlobals({
   bEthPriceLimits: BETH_PRICE_LIMITS && JSON.parse(BETH_PRICE_LIMITS),
   stEthRateLimits: STETH_RATE_LIMITS && JSON.parse(STETH_RATE_LIMITS),
   ethPriceLimits: ETH_PRICE_LIMITS && JSON.parse(ETH_PRICE_LIMITS),
+  requestTimeout: REQUEST_TIMEOUT && Number.parseInt(REQUEST_TIMEOUT, 10),
 })
 
 export function getBethPriceSafeStandalone() {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -20,6 +20,7 @@ var {
   STETH_RATE_LIMITS,
   ETH_PRICE_LIMITS,
   ETH_RPCS,
+  REQUEST_TIMEOUT,
 } = process.env
 
 setGlobals({

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -1,0 +1,40 @@
+/**
+ * standalone.js exposes bEthPriceSafe() function as a standalone function
+ * so it can be used as a function anywhere -- aside from cloudflare workers.
+ *
+ * All variables need to be injected via envvars
+ *
+ * Must not be used as an entry point.
+ */
+
+import { bEthPriceSafe } from './bEthPrice'
+import { setGlobals } from './globals'
+
+var {
+  ENV,
+  SENTRY_PROJECT_ID,
+  SENTRY_KEY,
+  DEVIATION_BLOCK_OFFSETS,
+  BETH_RATE_LIMITS,
+  BETH_PRICE_LIMITS,
+  STETH_RATE_LIMITS,
+  ETH_PRICE_LIMITS,
+  ETH_RPCS,
+} = process.env
+
+setGlobals({
+  env: ENV,
+  sentryProjectId: SENTRY_PROJECT_ID,
+  sentryKey: SENTRY_KEY,
+  ethRpcs: JSON.parse(ETH_RPCS),
+  deviationBlockOffsets:
+    DEVIATION_BLOCK_OFFSETS && JSON.parse(DEVIATION_BLOCK_OFFSETS),
+  bEthRateLimits: BETH_RATE_LIMITS && JSON.parse(BETH_RATE_LIMITS),
+  bEthPriceLimits: BETH_PRICE_LIMITS && JSON.parse(BETH_PRICE_LIMITS),
+  stEthRateLimits: STETH_RATE_LIMITS && JSON.parse(STETH_RATE_LIMITS),
+  ethPriceLimits: ETH_PRICE_LIMITS && JSON.parse(ETH_PRICE_LIMITS),
+})
+
+export function getBethPriceSafeStandalone() {
+  return bEthPriceSafe()
+}

--- a/test/standalone.test.js
+++ b/test/standalone.test.js
@@ -1,0 +1,29 @@
+import { assert } from 'chai'
+import { setGlobals } from '../src/globals'
+import { getBethPriceSafeStandalone } from '../src/standalone'
+
+describe('getBethPriceSafeStandalone', () => {
+  it('should resolve latest known price', async () => {
+    setGlobals({
+      ethRpcs: ['http://127.0.0.1:8545/'],
+      requestTimeout: 30000,
+    })
+
+    const price = await getBethPriceSafeStandalone()
+    assert.isDefined(price)
+  })
+
+  it('should throw upon timeout', async () => {
+    setGlobals({
+      ethRpcs: ['http://127.0.0.1:8545/'],
+      requestTimeout: 1,
+    })
+
+    getBethPriceSafeStandalone()
+      .catch(err => assert.isDefined(err))
+      .then(() => {
+        // should never arrive here
+        assert.fail()
+      })
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,7 @@ BETH_RATE_LIMITS = '{}'
 BETH_PRICE_LIMITS = '{"maxDeviations":[60,30,20]}'
 STETH_RATE_LIMITS = '{"maxDeviations":[5,1,0.5]}'
 ETH_PRICE_LIMITS = '{}'
+REQUEST_TIMEOUT = 10000
 
 
 [build]
@@ -36,6 +37,7 @@ BETH_RATE_LIMITS = '{}'
 BETH_PRICE_LIMITS = '{"maxDeviations":[60,30,20]}'
 STETH_RATE_LIMITS = '{"maxDeviations":[5,1,0.5]}'
 ETH_PRICE_LIMITS = '{}'
+REQUEST_TIMEOUT = 10000
 
 [env.production]
 workers_dev = false
@@ -52,3 +54,4 @@ BETH_RATE_LIMITS = '{}'
 BETH_PRICE_LIMITS = '{"maxDeviations":[60,30,20]}'
 STETH_RATE_LIMITS = '{"maxDeviations":[5,1,0.5]}'
 ETH_PRICE_LIMITS = '{}'
+REQUEST_TIMEOUT = 10000


### PR DESCRIPTION
This is a copy of #4 pointed to `main` (to avoid overwriting the fork's main branch).

- added a separate build artefact `build-standalone` which outputs an importable function for bETH price feed
- use `axios` instead of `fetch` for proper timeout handling
- added `requestTimeout` in globals; default is 30seconds. configurable via globals or envvars